### PR TITLE
Feature/console command @coderabbitai

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ composer require watheqalshowaiter/backup-tables
 Use the `BackupTables::generateBackup($tableToBackup)` Facade anywhere in your application and it will
 generate `$tableToBackup_backup_2024_08_22_17_40_01` table in the database with all the data and structure. Note that
 the datetime `2024_08_22_17_40_01` will be varied based on your datetime.
+ 
+You can also use the `php artisan backup:tables <targets>` command to back up tables,
+where `<targets>` is a space-separated list of tables names or models.
 
 ```php
 use WatheqAlshowaiter\BackupTables\BackupTables; // import the facade
@@ -35,7 +38,7 @@ class ChangeSomeData
     {
         BackupTables::generateBackup('users'); // will result: users_backup_2024_08_22_17_40_01
        
-        // change some data.. 
+        // change some data..
     }
 }
 ```
@@ -75,6 +78,12 @@ BackupTables::generateBackup('users', 'Y_d_m_H'); // can not generate the same b
 BackupTables::generateBackup('users', 'Y_d_m'); // can not generate the same backup in the same day
 ```
 
+- Using the artisan command for one or more tables/models
+```bash
+php artisan backup:tables users posts # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
+php artisan backup:tables \App\Models\User \App\Models\Post # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
+```
+
 ## Why?
 
 Sometimes you want to backup some database tables before changing data for whatever reason, this package serves this
@@ -84,6 +93,8 @@ beforehand.
 
 ## Features
 
+✅ Backup tables from the code or from the console command.
+ 
 ✅ Supports Laravel versions: 11, 10, 9, 8, 7, and 6.
 
 ✅ Supports PHP versions: 8.2, 8.1, 8.0, and 7.4.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 Backup single or multiple database tables with ease.
 
 > [!NOTE]
-> If you want a full database backup with many features, go for [Spatie Laravel Backup](https://github.com/spatie/laravel-backup).
+> If you want a full database backup with many features, go
+> for [Spatie Laravel Backup](https://github.com/spatie/laravel-backup).
 
 ## Installation
 
@@ -26,7 +27,7 @@ composer require watheqalshowaiter/backup-tables
 Use the `BackupTables::generateBackup($tableToBackup)` Facade anywhere in your application and it will
 generate `$tableToBackup_backup_2024_08_22_17_40_01` table in the database with all the data and structure. Note that
 the datetime `2024_08_22_17_40_01` will be varied based on your datetime.
- 
+
 You can also use the `php artisan backup:tables <targets>` command to back up tables,
 where `<targets>` is a space-separated list of table names or models.
 
@@ -59,7 +60,8 @@ BackupTables::generateBackup(['users', 'posts']);
 ```php
 BackupTables::generateBackup(User::class); // users_backup_2024_08_22_17_40_01
 // or
-BackupTables::generateBackup([User::class, Post::class]); // users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01 
+BackupTables::generateBackup([User::class, Post::class]); //-php artisan backup:tables users posts # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
+ users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01 
  
 ```
 
@@ -70,10 +72,9 @@ BackupTables::generateBackup('users', 'Y_d_m_H_i'); // users_backup_2024_22_08_1
 ```
 
 > [!WARNING]
-> Be aware if you customize the datetime to wide datetime the package will check the backup datetime file and
-> will be skipped
-> the same datetime, so most of the time the default will be fine
-> For example: if you use this `Y_d_m_H` you can not generate the same backup in the same hour
+> When customizing the datetime format, be aware that backups with identical datetime values will be skipped.
+> For example, if you use this `Y_d_m_H` you cannot generate the same backup in the same hour.
+> The default format (Y_m_d_H_i_s) is recommended for most cases.
 
 ```php
 BackupTables::generateBackup('users', 'Y_d_m_H'); // can not generate the same backup in the same hour
@@ -81,6 +82,7 @@ BackupTables::generateBackup('users', 'Y_d_m'); // can not generate the same bac
 ```
 
 - Using the artisan command for one or more tables/models
+
 ```bash
 php artisan backup:tables users posts # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
 php artisan backup:tables \\App\\Models\\User \\App\\Models\\Post # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
@@ -89,17 +91,18 @@ php artisan backup:tables \\App\\Models\\User \\App\\Models\\Post # users_backup
 ## Why?
 
 Sometimes you want to back up some database tables before changing data for whatever reason, this package serves this
-need. 
+need.
 
 I used it personally before adding foreign keys to tables that required removing unlinked fields from parent tables.
 
-You may find some situation where you play with table data, or you're afraid of missing data, so you back up these tables
+You may find some situation where you play with table data, or you're afraid of missing data, so you back up these
+tables
 beforehand.
 
 ## Features
 
 ✅ Backup tables from the code using (Facade) or from the console command.
- 
+
 ✅ Supports Laravel versions: 11, 10, 9, 8, 7, and 6.
 
 ✅ Supports PHP versions: 8.2, 8.1, 8.0, and 7.4.
@@ -122,9 +125,9 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on recent changes.
 
 ## Contributing
 
-If you have any ideas or suggestions to improve it or fix bugs, your contribution is welcome. 
+If you have any ideas or suggestions to improve it or fix bugs, your contribution is welcome.
 
-I encourage you to look at [todos](./todos.md) which are the most important features that need to be added. 
+I encourage you to look at [todos](./todos.md) which are the most important features that need to be added.
 
 If you have something different, submit an issue first to discuss or report a bug, then do a pull request.
 
@@ -138,10 +141,8 @@ them.
 - [Watheq Alshowaiter](https://github.com/WatheqAlshowaiter)
 - [Omar Alalwi](https://github.com/omaralalwi) - This package is based on his initial code.
 - [All Contributors](../../contributors)
-  
 
 And a special thanks to [The King Creative](https://www.facebook.com/thkingcreative) for the logo ✨
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 Backup single or multiple database tables with ease.
 
-> Note: if you want a full database backup with many features go for [Spatie Laravel Backup](https://github.com/spatie/laravel-backup).
+> [!NOTE]
+> If you want a full database backup with many features, go for [Spatie Laravel Backup](https://github.com/spatie/laravel-backup).
 
 ## Installation
 
@@ -27,7 +28,7 @@ generate `$tableToBackup_backup_2024_08_22_17_40_01` table in the database with 
 the datetime `2024_08_22_17_40_01` will be varied based on your datetime.
  
 You can also use the `php artisan backup:tables <targets>` command to back up tables,
-where `<targets>` is a space-separated list of tables names or models.
+where `<targets>` is a space-separated list of table names or models.
 
 ```php
 use WatheqAlshowaiter\BackupTables\BackupTables; // import the facade
@@ -45,7 +46,7 @@ class ChangeSomeData
 
 And More Customizations
 
-- You can use an array to backup more than one table
+- You can use an array to back up more than one table
 
 ```php
 BackupTables::generateBackup(['users', 'posts']); 
@@ -68,9 +69,10 @@ BackupTables::generateBackup([User::class, Post::class]); // users_backup_2024_0
 BackupTables::generateBackup('users', 'Y_d_m_H_i'); // users_backup_2024_22_08_17_40
 ```
 
-> *Note: be aware if you customize the datetime to wide datetime the package will check the backup datetime file and
+> [!WARNING]
+> Be aware if you customize the datetime to wide datetime the package will check the backup datetime file and
 > will be skipped
-> the exact same datetime, so most of the time the default will be fine
+> the same datetime, so most of the time the default will be fine
 > For example: if you use this `Y_d_m_H` you can not generate the same backup in the same hour
 
 ```php
@@ -81,19 +83,22 @@ BackupTables::generateBackup('users', 'Y_d_m'); // can not generate the same bac
 - Using the artisan command for one or more tables/models
 ```bash
 php artisan backup:tables users posts # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
-php artisan backup:tables \App\Models\User \App\Models\Post # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
+php artisan backup:tables \\App\\Models\\User \\App\\Models\\Post # users_backup_2024_08_22_17_40_01, posts_backup_2024_08_22_17_40_01
 ```
 
 ## Why?
 
-Sometimes you want to backup some database tables before changing data for whatever reason, this package serves this
-need. I used it personally before adding foreign keys for tables that required the removal of unlinked fields for parent tables.
-You may find some situation where you play with table data or you're afraid of missing data so you backup these tables
+Sometimes you want to back up some database tables before changing data for whatever reason, this package serves this
+need. 
+
+I used it personally before adding foreign keys to tables that required removing unlinked fields from parent tables.
+
+You may find some situation where you play with table data, or you're afraid of missing data, so you back up these tables
 beforehand.
 
 ## Features
 
-✅ Backup tables from the code or from the console command.
+✅ Backup tables from the code using (Facade) or from the console command.
  
 ✅ Supports Laravel versions: 11, 10, 9, 8, 7, and 6.
 
@@ -113,11 +118,15 @@ composer test
 
 ## Changelog
 
-Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+Please see [CHANGELOG](CHANGELOG.md) for more information on recent changes.
 
 ## Contributing
 
-If you have any ideas or suggestions to improve it or fix bugs, your contribution is welcome. I encourage you to look at [todos](./todos.md) which are the most important features that need to be added. If you have something different, submit an issue first to discuss or report a bug, then do a pull request.
+If you have any ideas or suggestions to improve it or fix bugs, your contribution is welcome. 
+
+I encourage you to look at [todos](./todos.md) which are the most important features that need to be added. 
+
+If you have something different, submit an issue first to discuss or report a bug, then do a pull request.
 
 ## Security Vulnerabilities
 

--- a/src/BackupTablesService.php
+++ b/src/BackupTablesService.php
@@ -111,7 +111,7 @@ class BackupTablesService
             'newCreatedTables' => "Newly created table: $newTableName",
         ];
 
-        // to prevent duplicating message if you use generateBackup() twice in the same request event for different tables
+        // to prevent a duplicating message if you use generateBackup() twice in the same request event for different tables
         Arr::forget($this->response, '0');
 
         return $result;

--- a/src/BackupTablesServiceProvider.php
+++ b/src/BackupTablesServiceProvider.php
@@ -3,6 +3,7 @@
 namespace WatheqAlshowaiter\BackupTables;
 
 use Illuminate\Support\ServiceProvider;
+use WatheqAlshowaiter\BackupTables\Commands\BackupTableCommand;
 
 class BackupTablesServiceProvider extends ServiceProvider
 {
@@ -13,9 +14,14 @@ class BackupTablesServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        // This migration works only in the package test
-        if ($this->app->runningInConsole() && $this->app->environment() === 'testing') {
-            $this->loadMigrationsFrom(__DIR__.'/../tests/database/migrations');
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                BackupTableCommand::class,
+            ]);
+
+            if($this->app->environment() === 'testing'){
+                $this->loadMigrationsFrom(__DIR__.'/../tests/database/migrations');
+            }
         }
     }
 }

--- a/src/Commands/BackupTableCommand.php
+++ b/src/Commands/BackupTableCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WatheqAlshowaiter\BackupTables\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Command\Command as CommandCodes;
+use WatheqAlshowaiter\BackupTables\BackupTables;
+
+class BackupTableCommand extends Command
+{
+    protected $signature = 'backup:tables {targets* : The table names or model classes to backup (space-separated)}';
+
+    protected $description = 'Backup a specific database table/s based on provided table names or model classes';
+
+    public function handle()
+    {
+        $tables = $this->argument('targets');
+
+        $tables = $this->getMultipleTables($tables);
+
+        try {
+            $result = BackupTables::generateBackup($tables);
+
+            if (!$result) {
+                $this->error('Failed to backup table.');
+                return CommandCodes::FAILURE;
+            }
+
+            return CommandCodes::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error("Error backing up table: {$e->getMessage()}");
+            return CommandCodes::FAILURE;
+        }
+    }
+
+    /**
+     * @param $table
+     *
+     * @return false|string[]
+     */
+    private function getMultipleTables($table)
+    {
+        $tablesArr = explode(' ', $table);
+
+        return array_filter($tablesArr, function ($item) {
+            return !empty($item);
+        });
+    }
+}

--- a/src/Commands/BackupTableCommand.php
+++ b/src/Commands/BackupTableCommand.php
@@ -3,11 +3,12 @@
 namespace WatheqAlshowaiter\BackupTables\Commands;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Command\Command as CommandCodes;
 use WatheqAlshowaiter\BackupTables\BackupTables;
 
 class BackupTableCommand extends Command
 {
+    const SUCCESS = 0;
+    const FAILURE = 1;
     protected $signature = 'backup:tables {targets* : The table names or model classes to backup (space-separated)}';
 
     protected $description = 'Backup a specific database table/s based on provided table names or model classes';
@@ -21,13 +22,13 @@ class BackupTableCommand extends Command
 
             if (!$result) {
                 $this->error('Failed to backup table.');
-                return CommandCodes::FAILURE;
+                return self::FAILURE;
             }
 
-            return CommandCodes::SUCCESS;
+            return self::SUCCESS;
         } catch (\Exception $e) {
             $this->error("Error backing up table: {$e->getMessage()}");
-            return CommandCodes::FAILURE;
+            return self::FAILURE;
         }
     }
 }

--- a/src/Commands/BackupTableCommand.php
+++ b/src/Commands/BackupTableCommand.php
@@ -16,8 +16,6 @@ class BackupTableCommand extends Command
     {
         $tables = $this->argument('targets');
 
-        $tables = $this->getMultipleTables($tables);
-
         try {
             $result = BackupTables::generateBackup($tables);
 
@@ -31,19 +29,5 @@ class BackupTableCommand extends Command
             $this->error("Error backing up table: {$e->getMessage()}");
             return CommandCodes::FAILURE;
         }
-    }
-
-    /**
-     * @param $table
-     *
-     * @return false|string[]
-     */
-    private function getMultipleTables($table)
-    {
-        $tablesArr = explode(' ', $table);
-
-        return array_filter($tablesArr, function ($item) {
-            return !empty($item);
-        });
     }
 }

--- a/tests/BackupTableCommandTest.php
+++ b/tests/BackupTableCommandTest.php
@@ -26,10 +26,7 @@ class BackupTableCommandTest extends TestCase
 
         $backupTablePattern = 'test_table_backup_'.now()->format('Y_m_d_H_i_s');
 
-        $this->assertTrue(
-            Schema::hasTable($backupTablePattern),
-            "Backup table was not created"
-        );
+        $this->assertTrue(Schema::hasTable($backupTablePattern));
     }
 
     /** @test */
@@ -46,10 +43,7 @@ class BackupTableCommandTest extends TestCase
 
         $backupTablePattern = 'test_table_backup_'.now()->format('Y_m_d_H_i_s');
 
-        $this->assertTrue(
-            Schema::hasTable($backupTablePattern),
-            "Backup table was not created"
-        );
+        $this->assertTrue(Schema::hasTable($backupTablePattern));
     }
 
     /** @test */
@@ -72,16 +66,13 @@ class BackupTableCommandTest extends TestCase
             });
         }
 
-        $this->artisan('backup:tables', ['targets' => implode('  ', $tables)])
+        $this->artisan('backup:tables', ['targets' => $tables])
             ->assertSuccessful();
 
         foreach ($tables as $table) {
             $backupTablePattern = $table.'_backup_'.now()->format('Y_m_d_H_i_s');
 
-            $this->assertTrue(
-                Schema::hasTable($backupTablePattern),
-                "Backup table was not created"
-            );
+            $this->assertTrue(Schema::hasTable($backupTablePattern));
         }
 
     }
@@ -91,32 +82,33 @@ class BackupTableCommandTest extends TestCase
     {
         $models = [Father::class, Mother::class];
 
-        $this->artisan('backup:tables', ['targets' => implode('  ', $models)])
+        $this->artisan('backup:tables', ['targets' => $models])
             ->assertSuccessful();
 
         $backupTablePattern1 = 'fathers_backup_'.now()->format('Y_m_d_H_i_s');
         $backupTablePattern2 = 'mothers_backup_'.now()->format('Y_m_d_H_i_s');
 
-        $this->assertTrue(
-            Schema::hasTable($backupTablePattern1),
-            "Backup table was not created"
-        );
+        $this->assertTrue(Schema::hasTable($backupTablePattern1));
 
-        $this->assertTrue(
-            Schema::hasTable($backupTablePattern2),
-            "Backup table was not created"
-        );
+        $this->assertTrue(Schema::hasTable($backupTablePattern2));
     }
 
     /** @test */
-    public function it_fails_when_any_table_does_not_exist()
+    public function it_fails_when_any_table_does_not_exist_but_saved_corrected_tables()
     {
         Schema::create('existing_table', function ($table) {
             $table->id();
             $table->timestamps();
         });
 
-        $this->artisan('backup:tables', ['targets' => 'existing_table non_existent_table'])
+        $this->artisan('backup:tables', ['targets' => 'existing_table', 'non_existent_table'])
             ->assertSuccessful();
+
+        $backupExistingTablePattern = 'existing_table_backup_'.now()->format('Y_m_d_H_i_s');
+        $backupNonExistingTablePattern = 'non_existent_table_backup_'.now()->format('Y_m_d_H_i_s');
+
+        $this->assertTrue(Schema::hasTable($backupExistingTablePattern));
+
+        $this->assertFalse(Schema::hasTable($backupNonExistingTablePattern));
     }
 }

--- a/tests/BackupTableCommandTest.php
+++ b/tests/BackupTableCommandTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace WatheqAlshowaiter\BackupTables\Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use WatheqAlshowaiter\BackupTables\Commands\BackupTableCommand;
+use WatheqAlshowaiter\BackupTables\Tests\Models\Father;
+use WatheqAlshowaiter\BackupTables\Tests\Models\Mother;
+
+class BackupTableCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_can_backup_a_table()
+    {
+        Schema::create('test_table', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $this->artisan('backup:tables', ['targets' => 'test_table'])
+            ->assertSuccessful();
+
+        $backupTablePattern = 'test_table_backup_'.now()->format('Y_m_d_H_i_s');
+
+        $this->assertTrue(
+            Schema::hasTable($backupTablePattern),
+            "Backup table was not created"
+        );
+    }
+
+    /** @test */
+    public function it_can_backup_a_table_by_classname()
+    {
+        Schema::create('test_table', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $this->artisan(BackupTableCommand::class, ['targets' => 'test_table'])
+            ->assertSuccessful();
+
+        $backupTablePattern = 'test_table_backup_'.now()->format('Y_m_d_H_i_s');
+
+        $this->assertTrue(
+            Schema::hasTable($backupTablePattern),
+            "Backup table was not created"
+        );
+    }
+
+    /** @test */
+    public function it_fails_when_table_does_not_exist()
+    {
+        $this->artisan('backup:tables', ['targets' => 'non_existent_table'])
+            ->assertFailed();
+    }
+
+    /** @test */
+    public function it_can_backup_multiple_tables()
+    {
+        $tables = ['test_table_1', 'test_table_2'];
+
+        foreach ($tables as $table) {
+            Schema::create($table, function ($table) {
+                $table->id();
+                $table->string('name');
+                $table->timestamps();
+            });
+        }
+
+        $this->artisan('backup:tables', ['targets' => implode('  ', $tables)])
+            ->assertSuccessful();
+
+        foreach ($tables as $table) {
+            $backupTablePattern = $table.'_backup_'.now()->format('Y_m_d_H_i_s');
+
+            $this->assertTrue(
+                Schema::hasTable($backupTablePattern),
+                "Backup table was not created"
+            );
+        }
+
+    }
+
+    /** @test */
+    public function it_can_backup_multiple_models()
+    {
+        $models = [Father::class, Mother::class];
+
+        $this->artisan('backup:tables', ['targets' => implode('  ', $models)])
+            ->assertSuccessful();
+
+        $backupTablePattern1 = 'fathers_backup_'.now()->format('Y_m_d_H_i_s');
+        $backupTablePattern2 = 'mothers_backup_'.now()->format('Y_m_d_H_i_s');
+
+        $this->assertTrue(
+            Schema::hasTable($backupTablePattern1),
+            "Backup table was not created"
+        );
+
+        $this->assertTrue(
+            Schema::hasTable($backupTablePattern2),
+            "Backup table was not created"
+        );
+    }
+
+    /** @test */
+    public function it_fails_when_any_table_does_not_exist()
+    {
+        Schema::create('existing_table', function ($table) {
+            $table->id();
+            $table->timestamps();
+        });
+
+        $this->artisan('backup:tables', ['targets' => 'existing_table non_existent_table'])
+            ->assertSuccessful();
+    }
+}

--- a/tests/BackupTableCommandTest.php
+++ b/tests/BackupTableCommandTest.php
@@ -16,7 +16,7 @@ class BackupTableCommandTest extends TestCase
     public function it_can_backup_a_table()
     {
         Schema::create('test_table', function ($table) {
-            $table->id();
+            $table->bigIncrements('id');
             $table->string('name');
             $table->timestamps();
         });
@@ -33,7 +33,7 @@ class BackupTableCommandTest extends TestCase
     public function it_can_backup_a_table_by_classname()
     {
         Schema::create('test_table', function ($table) {
-            $table->id();
+            $table->bigIncrements('id');
             $table->string('name');
             $table->timestamps();
         });
@@ -60,7 +60,7 @@ class BackupTableCommandTest extends TestCase
 
         foreach ($tables as $table) {
             Schema::create($table, function ($table) {
-                $table->id();
+                $table->bigIncrements('id');
                 $table->string('name');
                 $table->timestamps();
             });
@@ -97,7 +97,7 @@ class BackupTableCommandTest extends TestCase
     public function it_fails_when_any_table_does_not_exist_but_saves_corrected_tables()
     {
         Schema::create('existing_table', function ($table) {
-            $table->id();
+            $table->bigIncrements('id');
             $table->timestamps();
         });
 

--- a/tests/BackupTableCommandTest.php
+++ b/tests/BackupTableCommandTest.php
@@ -81,12 +81,13 @@ class BackupTableCommandTest extends TestCase
     public function it_can_backup_multiple_models()
     {
         $models = [Father::class, Mother::class];
+        $now = now();
 
         $this->artisan('backup:tables', ['targets' => $models])
             ->assertExitCode(BackupTableCommand::SUCCESS);
 
-        $backupTablePattern1 = 'fathers_backup_'.now()->format('Y_m_d_H_i_s');
-        $backupTablePattern2 = 'mothers_backup_'.now()->format('Y_m_d_H_i_s');
+        $backupTablePattern1 = 'fathers_backup_'.$now->format('Y_m_d_H_i_s');
+        $backupTablePattern2 = 'mothers_backup_'.$now->format('Y_m_d_H_i_s');
 
         $this->assertTrue(Schema::hasTable($backupTablePattern1));
 

--- a/tests/BackupTableCommandTest.php
+++ b/tests/BackupTableCommandTest.php
@@ -22,7 +22,7 @@ class BackupTableCommandTest extends TestCase
         });
 
         $this->artisan('backup:tables', ['targets' => 'test_table'])
-            ->assertSuccessful();
+            ->assertExitCode(BackupTableCommand::SUCCESS);
 
         $backupTablePattern = 'test_table_backup_'.now()->format('Y_m_d_H_i_s');
 
@@ -39,7 +39,7 @@ class BackupTableCommandTest extends TestCase
         });
 
         $this->artisan(BackupTableCommand::class, ['targets' => 'test_table'])
-            ->assertSuccessful();
+            ->assertExitCode(BackupTableCommand::SUCCESS);
 
         $backupTablePattern = 'test_table_backup_'.now()->format('Y_m_d_H_i_s');
 
@@ -50,7 +50,7 @@ class BackupTableCommandTest extends TestCase
     public function it_fails_when_table_does_not_exist()
     {
         $this->artisan('backup:tables', ['targets' => 'non_existent_table'])
-            ->assertFailed();
+            ->assertExitCode(BackupTableCommand::FAILURE);
     }
 
     /** @test */
@@ -67,7 +67,7 @@ class BackupTableCommandTest extends TestCase
         }
 
         $this->artisan('backup:tables', ['targets' => $tables])
-            ->assertSuccessful();
+            ->assertExitCode(BackupTableCommand::SUCCESS);
 
         foreach ($tables as $table) {
             $backupTablePattern = $table.'_backup_'.now()->format('Y_m_d_H_i_s');
@@ -83,7 +83,7 @@ class BackupTableCommandTest extends TestCase
         $models = [Father::class, Mother::class];
 
         $this->artisan('backup:tables', ['targets' => $models])
-            ->assertSuccessful();
+            ->assertExitCode(BackupTableCommand::SUCCESS);
 
         $backupTablePattern1 = 'fathers_backup_'.now()->format('Y_m_d_H_i_s');
         $backupTablePattern2 = 'mothers_backup_'.now()->format('Y_m_d_H_i_s');
@@ -94,7 +94,7 @@ class BackupTableCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_fails_when_any_table_does_not_exist_but_saved_corrected_tables()
+    public function it_fails_when_any_table_does_not_exist_but_saves_corrected_tables()
     {
         Schema::create('existing_table', function ($table) {
             $table->id();
@@ -102,7 +102,7 @@ class BackupTableCommandTest extends TestCase
         });
 
         $this->artisan('backup:tables', ['targets' => 'existing_table', 'non_existent_table'])
-            ->assertSuccessful();
+            ->assertExitCode(BackupTableCommand::SUCCESS);
 
         $backupExistingTablePattern = 'existing_table_backup_'.now()->format('Y_m_d_H_i_s');
         $backupNonExistingTablePattern = 'non_existent_table_backup_'.now()->format('Y_m_d_H_i_s');


### PR DESCRIPTION
 @coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new command `php artisan backup:tables` to back up specific database tables or models.
  - Supports backing up single or multiple tables/models in one command with examples provided.

- **Documentation**
  - Updated README with clearer instructions and examples for using the backup command.
  - Improved formatting and readability of documentation sections, including a new block-style note and expanded examples.

- **Improvements**
  - Enhanced command registration and error handling for backup functionality.

- **Tests**
  - Introduced new test suite to validate backup command functionality across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->